### PR TITLE
Add DisableTrimSlash

### DIFF
--- a/service.go
+++ b/service.go
@@ -24,7 +24,8 @@ var services = map[string]*Service{}
 // execution may quit anywhere else in the chain if the quit function
 // is called.
 type Service struct {
-	baseURI string
+	baseURI   string
+	trimSlash bool
 
 	pre  []contextHandler
 	post []contextHandler
@@ -42,9 +43,16 @@ func NewService(baseURI string) *Service {
 	}
 
 	return &Service{
-		baseURI: path.Join("/", baseURI, "/"),
-		routes:  map[string]*node{},
+		baseURI:   path.Join("/", baseURI, "/"),
+		routes:    map[string]*node{},
+		trimSlash: true,
 	}
+}
+
+// DisableTrimSlash disables the removal of trailing slashes
+// before route matching.
+func (s *Service) DisableTrimSlash() {
+	s.trimSlash = false
 }
 
 func addToChain(f interface{}, chain []contextHandler) []contextHandler {
@@ -92,7 +100,7 @@ func (s *Service) ServeHTTPInContext(c Context, w http.ResponseWriter, r *http.R
 		// The main handler is only run if we have not
 		// been signaled to quit.
 
-		if r.URL.Path != "/" {
+		if r.URL.Path != "/" && s.trimSlash {
 			r.URL.Path = strings.TrimRight(r.URL.Path, "/")
 		}
 


### PR DESCRIPTION
This is required for correct routing when [`http.FileServer`](https://golang.org/pkg/net/http/#FileServer) is used because it redirects `/path` to `/path/` if `path` is a directory. It also redirects `/path/index.html` to `/path/`.

Here is some code to reproduce:

```go
service := siesta.NewService("/")
// service.DisableTrimSlash()
service.SetNotFound(http.FileServer(http.Dir("/tmp")))
log.Fatal(http.ListenAndServe(":8080", service))
```