### PR TITLE
Skip empty items in slice parameters

### DIFF
--- a/params.go
+++ b/params.go
@@ -125,11 +125,13 @@ func (s *SBool) String() string {
 // It's a comma-separated list, so we split it.
 func (s *SBool) Set(value string) error {
 	for _, dt := range strings.Split(value, ",") {
-		parsed, err := strconv.ParseBool(dt)
-		if err != nil {
-			return err
+		if len(dt) > 0 {
+			parsed, err := strconv.ParseBool(dt)
+			if err != nil {
+				return err
+			}
+			*s = append(*s, parsed)
 		}
-		*s = append(*s, parsed)
 	}
 	return nil
 }
@@ -170,11 +172,13 @@ func (s *SInt) String() string {
 // It's a comma-separated list, so we split it.
 func (s *SInt) Set(value string) error {
 	for _, dt := range strings.Split(value, ",") {
-		parsed, err := strconv.ParseInt(dt, 0, 64)
-		if err != nil {
-			return err
+		if len(dt) > 0 {
+			parsed, err := strconv.ParseInt(dt, 0, 64)
+			if err != nil {
+				return err
+			}
+			*s = append(*s, int(parsed))
 		}
-		*s = append(*s, int(parsed))
 	}
 	return nil
 }
@@ -215,11 +219,13 @@ func (s *SInt64) String() string {
 // It's a comma-separated list, so we split it.
 func (s *SInt64) Set(value string) error {
 	for _, dt := range strings.Split(value, ",") {
-		parsed, err := strconv.ParseInt(dt, 0, 64)
-		if err != nil {
-			return err
+		if len(dt) > 0 {
+			parsed, err := strconv.ParseInt(dt, 0, 64)
+			if err != nil {
+				return err
+			}
+			*s = append(*s, int64(parsed))
 		}
-		*s = append(*s, int64(parsed))
 	}
 	return nil
 }
@@ -260,11 +266,13 @@ func (s *SUint) String() string {
 // It's a comma-separated list, so we split it.
 func (s *SUint) Set(value string) error {
 	for _, dt := range strings.Split(value, ",") {
-		parsed, err := strconv.ParseFloat(dt, 64)
-		if err != nil {
-			return err
+		if len(dt) > 0 {
+			parsed, err := strconv.ParseFloat(dt, 64)
+			if err != nil {
+				return err
+			}
+			*s = append(*s, uint(parsed))
 		}
-		*s = append(*s, uint(parsed))
 	}
 	return nil
 }
@@ -305,11 +313,13 @@ func (s *SUint64) String() string {
 // It's a comma-separated list, so we split it.
 func (s *SUint64) Set(value string) error {
 	for _, dt := range strings.Split(value, ",") {
-		parsed, err := strconv.ParseFloat(dt, 64)
-		if err != nil {
-			return err
+		if len(dt) > 0 {
+			parsed, err := strconv.ParseFloat(dt, 64)
+			if err != nil {
+				return err
+			}
+			*s = append(*s, uint64(parsed))
 		}
-		*s = append(*s, uint64(parsed))
 	}
 	return nil
 }
@@ -391,11 +401,13 @@ func (s *SFloat64) String() string {
 // It's a comma-separated list, so we split it.
 func (s *SFloat64) Set(value string) error {
 	for _, dt := range strings.Split(value, ",") {
-		parsed, err := strconv.ParseFloat(dt, 64)
-		if err != nil {
-			return err
+		if len(dt) > 0 {
+			parsed, err := strconv.ParseFloat(dt, 64)
+			if err != nil {
+				return err
+			}
+			*s = append(*s, parsed)
 		}
-		*s = append(*s, parsed)
 	}
 	return nil
 }
@@ -436,11 +448,13 @@ func (s *SDuration) String() string {
 // It's a comma-separated list, so we split it.
 func (s *SDuration) Set(value string) error {
 	for _, dt := range strings.Split(value, ",") {
-		parsed, err := time.ParseDuration(dt)
-		if err != nil {
-			return err
+		if len(dt) > 0 {
+			parsed, err := time.ParseDuration(dt)
+			if err != nil {
+				return err
+			}
+			*s = append(*s, parsed)
 		}
-		*s = append(*s, parsed)
 	}
 	return nil
 }

--- a/params.go
+++ b/params.go
@@ -267,7 +267,7 @@ func (s *SUint) String() string {
 func (s *SUint) Set(value string) error {
 	for _, dt := range strings.Split(value, ",") {
 		if len(dt) > 0 {
-			parsed, err := strconv.ParseFloat(dt, 64)
+			parsed, err := strconv.ParseUint(dt, 10, 64)
 			if err != nil {
 				return err
 			}
@@ -314,11 +314,11 @@ func (s *SUint64) String() string {
 func (s *SUint64) Set(value string) error {
 	for _, dt := range strings.Split(value, ",") {
 		if len(dt) > 0 {
-			parsed, err := strconv.ParseFloat(dt, 64)
+			parsed, err := strconv.ParseUint(dt, 10, 64)
 			if err != nil {
 				return err
 			}
-			*s = append(*s, uint64(parsed))
+			*s = append(*s, parsed)
 		}
 	}
 	return nil

--- a/params_test.go
+++ b/params_test.go
@@ -121,6 +121,7 @@ func TestParamsSlices(t *testing.T) {
 	floatVar := p.SliceFloat64("float", 0, "some float64")
 	v.Add("uint64", "1234")
 	v.Add("uint64", "1234,,5678,")
+	v.Add("uint64", "18446744073709551615") // 2^63-1
 	uint64Var := p.SliceUint64("uint64", 0, "some uint64")
 	v.Add("int64", "-9876")
 	v.Add("int64", "-9876,,8765,")
@@ -165,7 +166,7 @@ func TestParamsSlices(t *testing.T) {
 		}
 	}
 
-	uint64s := []uint64{1234, 1234, 5678}
+	uint64s := []uint64{1234, 1234, 5678, 18446744073709551615}
 	for i, v := range *uint64Var {
 		if v != uint64s[i] {
 			t.Errorf("expected %d, got %d", uint64s[i], v)

--- a/params_test.go
+++ b/params_test.go
@@ -108,28 +108,28 @@ func TestParamsSlices(t *testing.T) {
 	v := url.Values{}
 	p := Params{}
 	v.Add("company", "VividCortex")
-	v.Add("company", "Inc,comma")
+	v.Add("company", "Inc,,comma,")
 	company := p.SliceString("company", "", "the company name")
 	v.Add("founded", "2012")
-	v.Add("founded", "2012,2102")
+	v.Add("founded", "2012,,2102,")
 	founded := p.SliceInt("founded", 0, "when it was founded")
 	v.Add("startup", "true")
-	v.Add("startup", "false,true")
+	v.Add("startup", "false,,true,")
 	startup := p.SliceBool("startup", false, "whether it's a startup")
 	v.Add("float", "12.89")
-	v.Add("float", "1.25,12.625")
+	v.Add("float", "1.25,,12.625,")
 	floatVar := p.SliceFloat64("float", 0, "some float64")
 	v.Add("uint64", "1234")
-	v.Add("uint64", "1234,5678")
+	v.Add("uint64", "1234,,5678,")
 	uint64Var := p.SliceUint64("uint64", 0, "some uint64")
 	v.Add("int64", "-9876")
-	v.Add("int64", "-9876,8765")
+	v.Add("int64", "-9876,,8765,")
 	int64Var := p.SliceInt64("int64", 0, "some int64")
 	v.Add("uint", "2345")
-	v.Add("uint", "2345,3456")
+	v.Add("uint", "2345,,3456,")
 	uintVar := p.SliceUint("uint", 0, "some uint")
 	v.Add("duration", "10ms")
-	v.Add("duration", "10s,12ms")
+	v.Add("duration", "10s,,12ms,")
 	duration := p.SliceDuration("duration", 0, "how long it's been")
 
 	err := p.Parse(v)
@@ -137,7 +137,7 @@ func TestParamsSlices(t *testing.T) {
 		t.Error(err)
 	}
 
-	companies := []string{"VividCortex", "Inc", "comma"}
+	companies := []string{"VividCortex", "Inc", "", "comma", ""}
 	for i, v := range *company {
 		if v != companies[i] {
 			t.Errorf("expected %s, got %s", companies[i], v)


### PR DESCRIPTION
Empty items in slice parameters make parsing fail for numeric, boolean and duration types. Given that an empty value is not valid in any of those cases, we can safely ignore them. As a consequence, this update makes it possible to provide an entirely empty parameter, that would map to an empty slice. Before, there was no chance to make an empty slice other than not providing the parameter at all.